### PR TITLE
Added Cesium and i3s into layer id function to avoid error

### DIFF
--- a/R/mapdeck_map_utilities.R
+++ b/R/mapdeck_map_utilities.R
@@ -128,6 +128,8 @@ layerId <- function(
 		, "arc"
 		, "bitmap"
 		, "column"
+		, "cesium"
+		, "i3s"
 		, "geojson"
 		, "greatcircle"
 		, "grid"


### PR DESCRIPTION
experimental layers 'add_cesium' and 'add_i3" were producing the following error due to it not matching one of the stored layer ids; "Warning: Error in match.arg: 'arg' should be one of “animated_arc”, “animated_line”, “arc”, “bitmap”, “column”, “geojson”, “greatcircle”, “grid”, “h3”, “heatmap”, “hexagon”, “line”, “mesh”, “path”, “pointcloud”, “polygon”, “scatterplot”, “screengrid”, “terrain”, “text”, “tile3d”, “title”, “trips”"